### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,8 @@
 name: Release
 
+permissions:
+  contents: read
+
 on:
   push:
     tags:
@@ -91,6 +94,8 @@ jobs:
 
   release:
     needs: build
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/aszazeroth/rustynaut/security/code-scanning/8](https://github.com/aszazeroth/rustynaut/security/code-scanning/8)

Add explicit `permissions` blocks to `.github/workflows/release.yml`:

- At workflow root: set minimal default permission for all jobs:
  - `contents: read`
- At the `release` job: override with required write scope to create a GitHub release:
  - `contents: write`

This preserves existing functionality (build job remains read-only; release job can still publish release assets) while enforcing least privilege.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
