### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Potential fix for [https://github.com/aszazeroth/rustynaut/security/code-scanning/1](https://github.com/aszazeroth/rustynaut/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/rust.yml` at the workflow root so it applies to all jobs (including `build`) unless overridden.  
For this workflow, the minimal required permission is:

- `contents: read`

Best single fix without changing functionality:
- Insert:
  ```yml
  permissions:
    contents: read
  ```
  between the `on:` section and `env:` section (or anywhere at workflow root level).

No imports, methods, or dependency changes are needed—this is purely a YAML workflow configuration update.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
